### PR TITLE
scikit.learn has been renamed to sklearn

### DIFF
--- a/pywaveclus/cluster/skl.py
+++ b/pywaveclus/cluster/skl.py
@@ -2,8 +2,8 @@
 
 
 import numpy as np
-import scikits.learn.cluster
-import scikits.learn.mixture
+import sklearn.cluster
+import sklearn.mixture
 
 from .. import dsp
 
@@ -82,7 +82,7 @@ def cluster(waveforms, nfeatures, featuretype, nclusters, \
     else:
         raise ValueError("Unknown feature type[%s]" % featuretype)
 
-    kmeans = scikits.learn.cluster.KMeans(k=nclusters)
+    kmeans = sklearn.cluster.KMeans(k=nclusters)
     np.save('waves_%i' % features.shape[0], waveforms)
     np.save('features_%i' % features.shape[0], features)
     kmeans.fit(features)
@@ -99,7 +99,7 @@ def gmm(waveforms, nfeatures, ftype, nclusters, separate, pre, minspikes, \
     raise NotImplementedError("Not yet implemented")
     if len(waveforms) < minspikes:
         return np.zeros(len(waveforms)), {}
-    g = scikits.learn.mixture.GMM(nclusters, cvtype)
+    g = sklearn.mixture.GMM(nclusters, cvtype)
     if featuretype == 'pca':
         features, pca_info = dsp.pca.features(waveforms, nfeatures)
     pass

--- a/pywaveclus/dsp/ica.py
+++ b/pywaveclus/dsp/ica.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 
-import scikits.learn.decomposition
+import sklearn.decomposition
 
 
 def features(waveforms, nfeatures=6):
@@ -15,6 +15,6 @@ def features(waveforms, nfeatures=6):
             wf = np.hstack((wf, ch))
         waves.append(wf)
     waves = np.array(waves)
-    ica = scikits.learn.decomposition.FastICA(nfeatures)
+    ica = sklearn.decomposition.FastICA(nfeatures)
     ica.fit(waves.T)
     return ica.transform(waves.T).T

--- a/pywaveclus/dsp/pca.py
+++ b/pywaveclus/dsp/pca.py
@@ -5,7 +5,7 @@ import os
 import numpy as np
 
 # from matplotlib.mlab import PCA
-from scikits.learn.decomposition.pca import PCA
+from sklearn.decomposition.pca import PCA
 
 global FEATURES
 FEATURES = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ nose>=0.11
 numpy>=1.5.1
 scipy>=0.8.0
 scikits.audiolab>=0.11.0
-scikits.learn>=0.8.1
+scikit_learn>=0.8.1
 tables>=2.1.2
 pywavelets>=0.2.0


### PR DESCRIPTION
The code fails on importing because it tries to import `scikit.learn`, however this has been renamed to `sklearn`. This fixes it by replacing all instances of `scikit.learn` with `sklearn`.